### PR TITLE
feat: 建立项目术语表 terminology/

### DIFF
--- a/terminology/README.md
+++ b/terminology/README.md
@@ -1,0 +1,56 @@
+# 天圆地方 GeoCraft 术语表
+
+收录天圆地方及镍 API（Nickel API）创造并定义的概念，给出中英术语对照，供文档、翻译与开发时查证使用。
+
+## 文件划分
+
+| 文件 | 范围 |
+| --- | --- |
+| general.yaml | 框架级基础概念（层级、地理属性、地理状态等） |
+| atmosphere.yaml | 大气系统 |
+| fluidphysics.yaml | 流体物理（基础概念、各模式独有概念、压强系统，文件内以注释分段） |
+| fluid-host.yaml | 载流方块（分层流体承载方块及其单位、机制与典型案例雪族） |
+| soil.yaml | 土壤系统 |
+| commands.yaml | GeoCraft 的命令与命令参数名 |
+| nickel.yaml | 镍 API 底层框架（参数类型名、节点等） |
+| nickel-nbt.yaml | 镍 API 的 NBT 系统 |
+| misc.yaml | 跨系统难以归类的概念（待定区），以及不属于任何游戏系统的概念（如测试框架） |
+
+## 收录判据
+
+看概念的出生地：本模组文档中创造并定义的词才收录（纯文档定义的上层现象也算，无需代码实体）；物理学、地理学等领域已有的词，仅被借用来描述现象的（如虹吸效应）则不收录。配置项命名不作为术语依据。
+
+## 条目格式
+
+```yaml
+- 中文: "示例术语"
+  英文: "Example Term"
+  别称:
+    - ["中文别称"]
+    - ["English Alias"]
+  旧称:
+    - ["中文旧称"]
+    - ["Old English Name"]
+  定义: "一句话定义。"
+  出处:
+    - "https://www.mcmod.cn/item/xxxxxx.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/vX.Y.Z"
+```
+
+## 规则
+
+- **英文** 为 null = 尚未决定英文命名，文档与翻译中不得擅自命名。
+- 一个概念有多个正式英文名时，**英文** 可为列表，并以 `#` 注释注明各名的适用语境。
+- **别称** 为可选字段，值为两个列表：第一个列表为中文别称，第二个为英文别称（含简称、对应类名）。
+- **旧称** 为可选字段，结构同别称（先中文后英文），记录历史名称/曾用名。
+- 暂定（未正式定名）的名字放入别称，主名字段记 null。
+- **定义** 为可选字段，缺省时请见出处文档。
+- **出处** 为必填字段，值为列表，且必须为精确链接：仓库内文件指向具体 commit 的 blob/tree 链接，release note 指向对应 release 页，语言文件另注明键名。
+
+## 数据来源
+
+MC 百科资料页（[游戏设定](https://www.mcmod.cn/item/list/22470-10.html)与[方块/物品](https://www.mcmod.cn/item/list/22470-1.html)分类）、语言文件（assets/geocraft/lang、assets/nickelapi/lang）、双语 README 与主仓库 release note。
+
+## 维护
+
+新概念随引入它的提交一同入册；命名、定义或归类发生变化时同步更新对应条目。

--- a/terminology/atmosphere.yaml
+++ b/terminology/atmosphere.yaml
@@ -1,0 +1,220 @@
+# 天圆地方 GeoCraft 术语表 —— 大气系统
+# 范围：大气系统及其层级、属性、机制与存储格式。
+# 格式与规则见本目录 README.md。
+
+- 中文: "大气层级"
+  英文: "Atmosphere Layer"
+  定义: "层级的一种，是大气系统的组成部分之一。"
+  出处:
+    - "https://www.mcmod.cn/item/892845.html"
+
+- 中文: "下垫面层级"
+  英文: "Underlying Layer"
+  定义: "层级的一种，往住代表一个维度的地表部分，也是大气系统的重要组成部分。"
+  出处:
+    - "https://www.mcmod.cn/item/892846.html"
+
+- 中文: "大气系统"
+  英文: "Atmosphere System"
+  定义: "负责管理各维度中所有大气实例，并作为游戏其它机制与大气交互的抽象层。"
+  出处:
+    - "https://www.mcmod.cn/item/894655.html"
+
+- 中文: "大气实例"
+  英文: "Atmosphere Instance"
+  别称:
+    - ["大气", "地理单元"]
+    - []
+  定义: "每个区块中用于管理层级链并承担一定模拟计算的基础单元。"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "大气受热过程"
+  英文: null
+  定义: "大气受热过程是主世界大气系统中，太阳辐射、地面辐射和大气辐射相互转化的机制。"
+  出处:
+    - "https://www.mcmod.cn/item/894818.html"
+
+- 中文: "深层温度"
+  英文: "Deep Temperature"
+  定义: "主世界大气系统中下垫面层级的温度属性（geocraft:deep_temperature），用于地表之下的温度计算。"
+  出处:
+    - "https://www.mcmod.cn/item/894819.html"
+
+- 中文: "原版大气系统"
+  英文: "Vanilla Atmosphere System"
+  定义: "一种基于原版生物群系机制的静态大气系统，其在游戏内 ID 为 vanilla。"
+  出处:
+    - "https://www.mcmod.cn/item/894965.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+- 中文: "封闭大气系统"
+  英文: "Close Atmosphere System"
+  定义: "一种恒温恒压的静态大气系统，适合空间上封闭的维度，例如下界。"
+  出处:
+    - "https://www.mcmod.cn/item/904889.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README_EN.md"
+
+- 中文: "大气区域文件"
+  英文: "Atmosphere Region File"
+  别称:
+    - ["大气数据文件"]
+    - []
+  定义: "天圆地方保存大气实例数据的文件格式，类似原版区域文件，后缀一般为 .atmdat。"
+  出处:
+    - "https://www.mcmod.cn/item/905005.html"
+
+- 中文: "类地大气系统"
+  英文: "Surface Atmosphere System"
+  别称:
+    - ["表面大气系统", "表层大气系统", "主世界大气系统"]
+    - ["Surface Atmospheric System"]
+  定义: "模仿地球表层大气环境下物质迁移和能量循环的动态大气系统，适合空间上开放、类地球环境的维度。"
+  出处:
+    - "https://www.mcmod.cn/item/929712.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+- 中文: "大气刻"
+  英文: "Atmosphere Tick"
+  定义: "大气实例相邻两次运行的时间间隔，等于 60 游戏刻，是大气的模拟步长。"
+  出处:
+    - "https://www.mcmod.cn/item/894655.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md（中文版有定义句，英文版无对应章节）"
+
+- 中文: "大气访问器"
+  英文: "Atmosphere Accessor"
+  定义: "大气系统向外提供、供外部逻辑与大气交互的接口。"
+  出处:
+    - "https://www.mcmod.cn/item/894655.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "大气系统信息"
+  英文: "Atmosphere System Information"
+  定义: "配置中描述维度所用大气系统的 JSON 对象。"
+  出处:
+    - "https://www.mcmod.cn/item/894655.html"
+
+- 中文: "大气数据"
+  英文: "Atmosphere Data"
+  定义: "封装大气实例的对象，用于对大气实例进行数据管理。"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "大气数据提供器"
+  英文: "Atmosphere Data Provider"
+  定义: "响应大气系统请求、提供区块大气数据的组件。"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "大气数据加载器"
+  英文: "Atmosphere Data Loader"
+  定义: "在大气数据尚未加载时根据区块坐标加载数据的组件。"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "大气区域文件缓存"
+  英文: "Atmosphere Region File Cache"
+  定义: "缓存大气区域文件、供大气数据加载器获取数据输入流的组件。"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "大气监听器"
+  英文: "Atmosphere Tracker"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "大气区域"
+  英文: "Atmosphere Region"
+  定义: "一个大气区域文件所存储的大气范围，大小为 128×128 区块。"
+  出处:
+    - "https://www.mcmod.cn/item/905005.html"
+
+- 中文: "水气压"
+  英文: "Vapor Pressure"
+  定义: "大气中由水蒸气产生的分压，反映大气水汽含量的多少。"
+  出处:
+    - "https://www.mcmod.cn/item/894656.html"
+
+- 中文: "饱和水气压"
+  英文: "Saturated Vapor Pressure"
+  定义: "大气持有的水蒸气量达到饱和时水蒸气产生的分压，是温度的函数。"
+  出处:
+    - "https://www.mcmod.cn/item/894656.html"
+
+- 中文: "水汽交换率"
+  英文: "Vapor Exchange Rate"
+  定义: "调节蒸发快慢的系数，每个维度可拥有不同的值。"
+  出处:
+    - "https://www.mcmod.cn/item/894656.html"
+
+- 中文: "水汽"
+  英文: null
+  定义: "大部分大气系统的大气层级往往持有的气态水地理状态，单位为 mB。"
+  出处:
+    - "https://www.mcmod.cn/item/892845.html"
+
+- 中文: "液态水"
+  英文: null
+  定义: "大部分大气系统的大气层级往往持有的液态水地理状态，即大气层中云的组成部分，单位为 mB。"
+  出处:
+    - "https://www.mcmod.cn/item/892845.html"
+
+- 中文: "层级链"
+  英文: null
+  定义: "大气实例在垂直方向上由一个或多个层级堆叠形成的结构。"
+  出处:
+    - "https://www.mcmod.cn/item/894817.html"
+
+- 中文: "下垫面"
+  英文: "Underlying"
+  定义: "大气系统中与大气进行物质和能量交换的地表部分，下垫面层级即以其命名。"
+  出处:
+    - "https://www.mcmod.cn/item/892846.html"
+
+- 中文: "云量指数"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/894965.html"
+
+- 中文: "大气水"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/894656.html"
+
+- 中文: "热量收支平衡的移动"
+  英文: null
+  定义: "地区温度在游戏进行中缓慢波动地趋向热量收支平衡状态的现象。"
+  出处:
+    - "https://www.mcmod.cn/item/929712.html"
+
+- 中文: "流动性"
+  英文: null
+  定义: "大气属性可能具有的特性，具有流动性的大气属性能以平流和对流方式流动。"
+  出处:
+    - "https://www.mcmod.cn/item/894342.html"
+
+- 中文: "平流"
+  英文: null
+  定义: "大气属性在水平方向上的流动，发生在区块与区块的交界处。"
+  出处:
+    - "https://www.mcmod.cn/item/894342.html"
+
+- 中文: "对流"
+  英文: "Convection"
+  定义: "大气属性在竖直方向上的流动，发生在大气层级竖直方向的交界处。"
+  出处:
+    - "https://www.mcmod.cn/item/894342.html"
+    - "https://www.mcmod.cn/item/894818.html"
+
+- 中文: "热对流"
+  英文: null
+  定义: "大气层级间通过对流传递热量的过程。"
+  出处:
+    - "https://www.mcmod.cn/item/894818.html"
+
+- 中文: "风"
+  英文: null
+  定义: "大气层级持有的地理状态，以三维向量表示，单位为方块/秒。"
+  出处:
+    - "https://www.mcmod.cn/item/892845.html"

--- a/terminology/commands.yaml
+++ b/terminology/commands.yaml
@@ -1,0 +1,141 @@
+# 天圆地方 GeoCraft 术语表 —— 命令与命令参数名
+# 范围：GeoCraft 的命令、命令概念，以及语言文件中已定的命令参数名（*.arg.*）。
+# 格式与规则见本目录 README.md。
+- 中文: "/atmosphere"
+  英文: null
+  定义: "/atmosphere 是用于管理大气系统的命令。"
+  出处:
+    - "https://www.mcmod.cn/item/927875.html"
+
+- 中文: "/fluidphysics"
+  英文: null
+  定义: "/fluidphysics 是用于管理流体物理的命令。"
+  出处:
+    - "https://www.mcmod.cn/item/927876.html"
+
+- 中文: "/geoconfig"
+  英文: null
+  定义: "/geoconfig 是用于管理天圆地方模组的配置的命令。"
+  出处:
+    - "https://www.mcmod.cn/item/950633.html"
+
+- 中文: "/geotest"
+  英文: null
+  定义: "/geotest 是用于在游戏中进行 GeoTest 集成测试的命令。"
+  出处:
+    - "https://www.mcmod.cn/item/950634.html"
+
+- 中文: "位置"
+  英文: "Position"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.common.arg.pos）"
+
+- 中文: "值"
+  英文: "Value"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.common.arg.value）"
+
+- 中文: "乘数"
+  英文: "Multiplier"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.common.arg.multiply）"
+
+- 中文: "属性"
+  英文: "Property"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.common.arg.property）"
+
+- 中文: "维度"
+  英文: "Dimension"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.common.arg.world）"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.dimension）"
+
+- 中文: "执行"
+  英文: "Execute"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.common.arg.doit）"
+
+- 中文: "需要查询的方块状态"
+  英文: "Block State to Query"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.block_to_query）"
+
+- 中文: "工具名称"
+  英文: "Utility Name"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.util_name）"
+
+- 中文: "追踪时长"
+  英文: "Duration"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.time）"
+
+- 中文: "文件名"
+  英文: "File Name"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.file_name）"
+
+- 中文: "方块物理属性"
+  英文: "Block Physics Property"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.blockProp）"
+
+- 中文: "NBT 值"
+  英文: "NBT Value"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.nbt_tag）"
+
+- 中文: "测试ID"
+  英文: "Test ID"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.geotest.arg.test_id）"
+
+- 中文: "测试目标"
+  英文: "Test Target"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.geotest.arg.target）"
+
+- 中文: "配置项"
+  英文: "Config Item"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.geoconfig.arg.config_entry）"
+
+- 中文: "配置值"
+  英文: "Config Value"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.geoconfig.arg.config_value）"
+
+- 中文: "请求 ID"
+  英文: "Request ID"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.geoconfig.arg.request_id）"
+
+- 中文: "查询结果"
+  英文: "QueryResult"
+  定义: "命令执行后存储的数值结果，可被 /stats 追踪到计分板。"
+  出处:
+    - "https://www.mcmod.cn/item/927875.html"
+
+- 中文: "请求令牌"
+  英文: null
+  定义: "/geoconfig 重置操作携带的 UUID 令牌，用于确认操作。"
+  出处:
+    - "https://www.mcmod.cn/item/950633.html"

--- a/terminology/fluid-host.yaml
+++ b/terminology/fluid-host.yaml
@@ -1,0 +1,102 @@
+# 天圆地方 GeoCraft 术语表 —— 载流方块
+# 范围：分层流体承载方块（载流方块）及其单位、机制与典型案例（雪族）。
+# 格式与规则见本目录 README.md。
+
+- 中文: "分层流体承载方块"
+  英文: "Layered Fluid Host Block"
+  别称:
+    - ["载流方块"]
+    - []
+  旧称:
+    - ["透水方块"]
+    - []
+  定义: "一种能够以竖直方向的层状结构储存一种或多种流体的方块。"
+  出处:
+    - "https://www.mcmod.cn/item/895381.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-alpha.1"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+- 中文: "含水方块"
+  英文: null
+  定义: "可容纳水的方块（对应接口 IFluidloggable），是载流方块的子集。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.2"
+
+- 中文: "层"
+  英文:
+    - "Layer"   # 描述非常规流体方块和其他载流方块（如雪）时使用
+    - "Quanta"  # 描述常规流体方块（继承 BlockFluidBase/BlockLiquid）或含水方块时使用，为 Forge 源码与 Fluidlogged API 的规范
+  别称:
+    - ["片"]
+    - []
+  定义: "一个流体单位，指流体方块和载流方块的最小不可分割部分，一般 8 层液体即为一个完整流体方块。"
+  出处:
+    - "https://www.mcmod.cn/item/892678.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.3"
+
+- 中文: "层—毫桶统一流体单位"
+  英文: "Quanta-Millibucket Unified Fluid Unit"
+  别称:
+    - []
+    - ["Q-mB Unified Unit"]
+  定义: "用于载流方块底层的高精度流体单位，符号 QB，1 B = 72072000 QB。"
+  出处:
+    - "https://www.mcmod.cn/item/895382.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-alpha.1"
+
+- 中文: "每方块最大层数"
+  英文: "Quanta Per Block"
+  别称:
+    - ["每方块流体量"]
+    - []
+  定义: "流体方块可容纳的最大层数，取值范围 1~16。"
+  出处:
+    - "https://www.mcmod.cn/item/895381.html"
+    - "https://www.mcmod.cn/item/895382.html"
+    - "又称\"每方块流体量\"见 https://www.mcmod.cn/item/919288.html"
+
+- 中文: "平均流动"
+  英文: "Average Flow"
+  定义: "有限模式流动方式之四，与水平相邻可流入方块平均分配流体。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-alpha.1"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-alpha.2"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.2"
+
+- 中文: "平均流动算法"
+  英文: null
+  定义: "计算平均流动分配结果的算法。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "流动选择"
+  英文: "Flow Choice"
+  定义: "平均流动中记录一个可流入方向载流方块元数据的对象。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "雪"
+  英文: "Snow"
+  定义: "由松散固态水冰晶组成的方块，本模组拓展其方块状态与机制。"
+  出处:
+    - "https://www.mcmod.cn/item/894816.html"
+
+- 中文: "流体雪"
+  英文: null
+  定义: "流体意义上的雪（与雪方块相对）：以层为单位计量，可与水以任意比例在一格内混合，密度小于水。"
+  出处:
+    - "https://www.mcmod.cn/item/894816.html"
+
+- 中文: "雪水混合物"
+  英文: "snow-water mixture"
+  别称:
+    - ["混雪"]
+    - []
+  定义: "水和流体雪以 1:1 比例混合形成的雪方块。"
+  出处:
+    - "https://www.mcmod.cn/item/894816.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README_EN.md（\"Adds snow-water mixtures\"）"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.6"

--- a/terminology/fluidphysics.yaml
+++ b/terminology/fluidphysics.yaml
@@ -1,0 +1,556 @@
+# 天圆地方 GeoCraft 术语表 —— 流体物理
+# 范围：流体物理系统基础概念、各流体物理模式的独有概念，以及压强系统。
+# 格式与规则见本目录 README.md。
+
+# ============ 流体物理系统 ============
+
+- 中文: "流体物理系统"
+  英文: "Fluid Physics System"
+  别称:
+    - ["流体物理"]
+    - []
+  定义: "Minecraft 原版、天圆地方及其他模组中所有驱动流体方块所承载流体发生转移或相变的机制集合。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "流体物理模式"
+  英文: "Fluid Physics Mode"
+  定义: "天圆地方提供的多种流体物理系统，每种系统即一个模式。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "流体物理信息"
+  英文: "Fluid Physics Info"
+  定义: "维度层面针对流体物理系统的 JSON 配置，具有版本控制。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "设计"
+  英文: "Design"
+  定义: "流体方块承载流体的方式，目前存在经典设计和有限设计两种。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "经典设计"
+  英文: "Classic Design"
+  定义: "流体方块可以承载也可以不承载流体的设计，如原版流体。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md（中文版有定义句，英文版无对应命名）"
+
+- 中文: "有限设计"
+  英文: "Finite Design"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+- 中文: "流动等级"
+  英文: "Level"
+  别称:
+    - ["等级"]
+    - []
+  定义: "记录流体方块状态的等级值，经典模式下 0 级为流体源方块。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "流体源方块"
+  英文: "Fluid Source"
+  别称:
+    - ["流体源块", "流体源", "源块"]
+    - []
+  定义: "经典设计中，能够承载流体的流体方块，实际承载量往往为 1 B。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README_EN.md（\"the concept of fluid sources still applies\"）"
+
+- 中文: "非流体源方块"
+  英文: null
+  别称:
+    - ["非流体源", "非源块"]
+    - []
+  定义: "经典设计中，不能承载流体的流体方块。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "传播性"
+  英文: null
+  定义: "流体方块可以进行自然传播的性质。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "依赖性"
+  英文: null
+  定义: "在不考虑跨系统交互的前提下，非源块需依赖承载相同流体的流体方块维持其存在的性质。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "恒定性"
+  英文: null
+  定义: "流体方块在传播过程中本身承载流体量保持不变的性质。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "守恒性"
+  英文: null
+  定义: "传播范围内流体方块承载相同流体总量保持不变的性质。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "流动"
+  英文: "Flow"
+  定义: "流体方块的传播与所承载流体主动跨系统转移行为的统称。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "自然传播"
+  英文: null
+  别称:
+    - ["传播"]
+    - []
+  定义: "流体方块主动在附近生成新流体方块或改变附近同种流体方块承载量的过程。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "竖直下落"
+  英文: null
+  别称:
+    - ["垂直流动"]
+    - []
+  定义: "流体流动首先尝试的方式，发生于下方方块可被该流体流入时。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.2"
+
+- 中文: "直接下落"
+  英文: null
+  定义: "竖直下落的一种，流体源方块直接将自身移动至下方一格。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "竖直下落算法"
+  英文: null
+  定义: "直接下落对应的算法。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "水平均衡"
+  英文: "Equalisation"
+  定义: "流动规则的一类，使流体在水平方向上趋于均衡。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "纳流"
+  英文: "Fluid Implacement"
+  定义: "放置载流方块时被填充流体优先填充新方块的被动转移过程。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "排流"
+  英文: "Fluid Displacement"
+  定义: "纳流后剩余流体以流体方块形式重新分布在周围的过程。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "重力系统"
+  英文: null
+  定义: "流体物理中与重力相关的机制。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+- 中文: "流体更新器"
+  英文: "Fluid Updater"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "标准测试"
+  英文: "Standard Test"
+  定义: "一种常用的流体物理性能测试方法，往往能够综合体现出各流动算法（规则）的物理和性能特性。"
+  出处:
+    - "https://www.mcmod.cn/item/907797.html"
+
+- 中文: "漏海测试"
+  英文: null
+  别称:
+    - ["漏海"]
+    - []
+  出处:
+    - "https://www.mcmod.cn/item/908015.html"
+    - "https://www.mcmod.cn/item/894341.html"
+    - "https://www.mcmod.cn/item/907797.html"
+    - "https://www.mcmod.cn/item/908016.html"
+
+- 中文: "含水方块困境"
+  英文: null
+  定义: "Minecraft 1.13+ 含水方块的二元态底层设计给有限设计流体带来的适配困境。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "涌泉难题"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "无限源需求"
+  英文: null
+  定义: "有限设计下玩家希望部分场景流体取之不尽、并借此降低流动计算开销的需求。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "水车问题"
+  英文: null
+  定义: "有限设计下水位差难以表达，致使经典设计水车玩法失效的问题。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+# ============ 原版模式 ============
+
+- 中文: "原版模式"
+  英文: "VANILLA"
+  定义: "一种保留原版流体行为的流体物理模式。"
+  出处:
+    - "https://www.mcmod.cn/item/904887.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+# ============ 经典模式 ============
+
+- 中文: "经典模式"
+  英文: "CLASSIC"
+  旧称:
+    - []
+    - ["VANILLA LIKE"]
+  定义: "在原版流体转移和相变机制上改良、使流体更符合物理直觉的经典设计拟真流体物理模式。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2（模式称呼改为\"经典\"（CLASSIC））"
+
+- 中文: "坡度流动"
+  英文: "Slope Flow"
+  定义: "流体流动最后尝试的方式，与原版保持一致的流动方式。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.2"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.4"
+
+- 中文: "坡度流动算法"
+  英文: "Slope Algorithm"
+  定义: "基于坡度大小计算坡度最大方向集合的原版流动算法。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "溯源下落"
+  英文: null
+  定义: "竖直下落的一种，非源流体方块通过溯源算法寻找流体源并使其瞬移至下方。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "溯源搬运"
+  英文: null
+  定义: "经典模式流动方式，寻找更高水位流体源并与自身交换。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+- 中文: "溯源流动"
+  英文: null
+  定义: "溯源下落与溯源搬运的统称。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.2"
+
+- 中文: "溯源搜索"
+  英文: null
+  定义: "溯源流动中寻找可被移动流体源的搜索过程。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-alpha.3"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.2"
+
+- 中文: "溯源算法"
+  英文: null
+  定义: "基于广度优先搜索、按流动等级剪枝的流体源搜索算法。"
+  出处:
+    - "https://www.mcmod.cn/item/904888.html"
+
+# ============ 有限模式 ============
+
+- 中文: "有限模式"
+  英文: "FINITE"
+  旧称:
+    - []
+    - ["MORE REALITY"]
+  定义: "基于体素、使流体方块遵循基本转移与相变规则从而涌现物理直觉行为的有限设计拟真流体物理模式，默认启用。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2（模式称呼改为\"有限\"（FINITE））"
+
+- 中文: "单层坡度流动"
+  英文: "Single-slope Flow"
+  定义: "有限模式流动方式之三，单层流体沿坡度随机移动一格。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "单层坡度流动算法"
+  英文: "Single-slope Flow Algorithm"
+  定义: "为单层流体寻找可流动方向的算法。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "多层坡度流动"
+  英文: "Multi-slope Flow"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "多层坡度流动算法"
+  英文: "Multi-slope Flow Algorithm"
+  定义: "精确到流体方块层数的坡度流动算法。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "坡度搜寻距离"
+  英文: "Slope Find Distance"
+  定义: "单层坡度流动算法的搜寻范围，单位为格。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "多层坡度搜寻距离"
+  英文: null
+  定义: "多层坡度流动算法的搜寻范围，单位为格。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "密度交换下落"
+  英文: null
+  定义: "竖直下落的一种，基于密度差与下方流体交换位置。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "载流方块交互式下落"
+  英文: null
+  定义: "竖直下落的一种，流体下落进入下方载流方块。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "下沉阈值"
+  英文: "Sinking Threshold"
+  定义: "船周边最高水位需高于船碰撞箱顶部的距离，超过才触发下沉。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "小范围压强任务"
+  英文: null
+  定义: "最大搜寻范围为 511 格的压强任务。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "大范围压强任务"
+  英文: null
+  定义: "最大搜寻范围为 1048575 格的压强任务。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.1"
+
+- 中文: "单次搜寻任务"
+  英文: null
+  定义: "可在单次搜寻中完成、可共用队列和集合的压强任务。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-beta.1"
+
+- 中文: "压强搜寻范围等级"
+  英文: null
+  定义: "表示发布压强任务时压强搜寻范围大小的等级值。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "小范围（原版）单次压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "小范围（原版）普通压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "大范围（原版）单次压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "大范围（原版）普通压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "小范围（模组）单次压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "小范围（模组）普通压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "大范围（模组）单次压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "大范围（模组）普通压强任务"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+# ============ 压强系统 ============
+
+- 中文: "压强系统"
+  英文: "Pressure System"
+  别称:
+    - []
+    - ["Fluid Pressure System"]
+  定义: "天圆地方流体物理系统中一个专门处理压强流动核心计算逻辑的子系统。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md"
+
+- 中文: "压强刻"
+  英文: "Pressure Tick"
+  定义: "计量异步压强系统大循环完成次数的单位，默认理想时长 40 毫秒。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "压强任务"
+  英文: null
+  定义: "压强系统为寻找可流入位置而处理的广度优先搜寻任务。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "压强流动"
+  英文: "Pressure Flow"
+  定义: "有限模式流动方式之二，按压强计算结果向可流入位置转移。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.1"
+
+- 中文: "压强任务执行颗粒度"
+  英文: "Pressure Task Execution Granularity"
+  别称:
+    - ["颗粒度"]
+    - []
+  定义: "压强系统每一批次处理的最大任务数量。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "异步模式"
+  英文: "Asynchronous"
+  定义: "压强系统不阻塞服务器线程的运行模式，与同步模式相对。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "异步多线程模式"
+  英文: null
+  旧称:
+    - ["多线程模式"]
+    - []
+  定义: "压强系统的运行模式之一。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "异步单线程模式"
+  英文: null
+  旧称:
+    - ["线程池模式"]
+    - []
+  定义: "压强系统的运行模式之一。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "同步单线程模式"
+  英文: "Synchronous Single-threaded"
+  旧称:
+    - ["非线程池模式"]
+    - []
+  定义: "压强系统的运行模式之一。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "暂停机制"
+  英文: null
+  定义: "服务器线程执行重要操作前通过锁使压强系统暂停访问的机制。"
+  出处:
+    - "https://www.mcmod.cn/item/894341.html"
+
+- 中文: "压强处理比"
+  英文: "Pressure Processing Ratio"
+  别称:
+    - []
+    - ["PPR"]
+  定义: "服务器线程处理单个压强结果用时与压强系统处理单个任务用时之比。"
+  出处:
+    - "https://www.mcmod.cn/item/908015.html"
+
+- 中文: "压强系统饱和每刻毫秒数"
+  英文: "Pressure-System Saturated Millisecond Per Tick"
+  别称:
+    - []
+    - ["PSS-MSPT"]
+  定义: "PSS 现象出现时 MSPT 稳定的平台值。"
+  出处:
+    - "https://www.mcmod.cn/item/908015.html"
+
+- 中文: "伪压强系统饱和每刻毫秒数"
+  英文: "Quasi-Pressure-System Saturated Millisecond Per Tick"
+  别称:
+    - ["伪 PSS-MSPT"]
+    - []
+  定义: "伪 PSS 现象出现时 MSPT 达到的平衡值。"
+  出处:
+    - "https://www.mcmod.cn/item/908017.html"
+
+- 中文: "多线程压强系统理想模型"
+  英文: "Multi-threaded Pressure System Theoretical Model"
+  别称:
+    - ["压强系统饱和模型", "理想模型", "PSS 模型"]
+    - []
+  定义: "通过理想化假设建立服务器线程与压强系统间数学关系、推导高负载理论行为的抽象数学模型。"
+  出处:
+    - "https://www.mcmod.cn/item/908014.html"
+
+- 中文: "基础负载修正理想模型"
+  英文: null
+  定义: "引入服务器线程基础负载值后对多线程压强系统理想模型的修正。"
+  出处:
+    - "https://www.mcmod.cn/item/908015.html"
+
+- 中文: "压强系统饱和平衡"
+  英文: "Pressure-System Saturation Equilibrium"
+  别称:
+    - []
+    - ["PSS"]
+  定义: "压强处理比（PPR）小于等于 1 时，高负载下 MSPT 稳定波动于一个平台值的良性限流现象。"
+  出处:
+    - "https://www.mcmod.cn/item/908015.html"
+
+- 中文: "反压强系统饱和平衡"
+  英文: "Anti-Pressure-System Saturation Equilibrium"
+  别称:
+    - ["反 PSS"]
+    - []
+  定义: "PPR 大于 1 时 MSPT 不受控增长的理论现象，实际中会演化为伪 PSS 现象。"
+  出处:
+    - "https://www.mcmod.cn/item/908016.html"
+
+- 中文: "伪压强系统饱和平衡"
+  英文: "Quasi-Pressure-System Saturation Equilibrium"
+  别称:
+    - ["伪 PSS"]
+    - []
+  定义: "PPR 大于 1 时因服务器线程延长游戏刻而达到的表观平衡，并非压强系统真正饱和。"
+  出处:
+    - "https://www.mcmod.cn/item/908017.html"

--- a/terminology/general.yaml
+++ b/terminology/general.yaml
@@ -1,0 +1,126 @@
+# 天圆地方 GeoCraft 术语表 —— 通用概念与系统交集
+# 范围：跨系统共用的框架级基础概念（层级、地理属性/状态、海拔、配置类型、方块更新器等）。
+# 格式与规则见本目录 README.md。
+
+- 中文: "层级"
+  英文: "Layer"
+  定义: "在一个区块内，竖直方向上横跨一定距离的空间。"
+  出处:
+    - "https://www.mcmod.cn/item/892675.html"
+
+- 中文: "地理属性"
+  英文: "Geography Property"
+  别称:
+    - ["属性"]
+    - []
+  定义: "大气系统以及其它基于层级实现的系统中用以定义地理状态和创建地理状态实例的标识符。"
+  出处:
+    - "https://www.mcmod.cn/item/892676.html"
+
+- 中文: "地理状态"
+  英文: "Geography State"
+  别称:
+    - ["状态"]
+    - []
+  定义: "狭义指地理属性在特定层级中存储具体数据（部分可持久化为 NBT）的实例；广义指层级的所有具体数据。"
+  出处:
+    - "https://www.mcmod.cn/item/892677.html"
+
+- 中文: "流体状态"
+  英文: "Fluid State"
+  别称:
+    - ["流体地理状态"]
+    - []
+  定义: "地理状态的一种，可被调用 fill 方法补充流体。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "海拔"
+  英文: "Altitude"
+  定义: "以Y轴正方向为正方向，世界中某坐标相对于水平参考平面的垂直距离。"
+  出处:
+    - "https://www.mcmod.cn/item/892847.html"
+
+- 中文: "映射表"
+  英文: "Map"
+  定义: "本模组基于 Forge 配置文件字符串列表定义的新配置类型，表示一系列具有映射关系的数据。"
+  出处:
+    - "https://www.mcmod.cn/item/892905.html"
+
+- 中文: "方块状态选择器"
+  英文: "Configurable Block State"
+  定义: "本模组配置文件中用以选择一种或多种方块状态的值类型。"
+  出处:
+    - "https://www.mcmod.cn/item/892906.html"
+
+- 中文: "热容"
+  英文: "Heat Capacity"
+  定义: "天圆地方对方块添加的属性，也是层级的一种地理属性，表示温度每升高一单位所需吸收的热量。"
+  出处:
+    - "https://www.mcmod.cn/item/905244.html"
+
+- 中文: "大气属性"
+  英文: "Atmosphere Property"
+  定义: "一种地理属性，其往往具有流动性或会对大气层级本身的流动性（风）或其它地理状态造成影响，例如水蒸气。"
+  出处:
+    - "https://www.mcmod.cn/item/894342.html"
+
+- 中文: "温度属性"
+  英文: "Temperature Property"
+  别称:
+    - ["温度"]
+    - []
+  定义: "大气以及其他层级的一类采用单精度浮点数进行存储，单位为开尔文（K）的地理属性。"
+  出处:
+    - "https://www.mcmod.cn/item/894343.html"
+
+- 中文: "方块更新器"
+  英文: "Block Updater"
+  定义: "为管理流体方块计划刻引入的延时方块更新机制，在原版计划刻基础上针对流体更新拓展，可配置。"
+  出处:
+    - "https://www.mcmod.cn/item/904958.html"
+
+- 中文: "更新计划"
+  英文: "Next Tick Entry"
+  别称:
+    - []
+    - ["NTE"]
+  定义: "方块更新器中记录一次延时方块更新的条目。"
+  出处:
+    - "https://www.mcmod.cn/item/904958.html"
+
+- 中文: "游戏海拔"
+  英文: null
+  定义: "以 Y=0 水平面为参考平面、方块为单位的海拔，数值等于 Y 坐标。"
+  出处:
+    - "https://www.mcmod.cn/item/892847.html"
+
+- 中文: "物理海拔"
+  英文: null
+  定义: "以 Y=63 水平面为参考平面、米为单位的海拔，用于地理模型计算。"
+  出处:
+    - "https://www.mcmod.cn/item/892847.html"
+
+- 中文: "反射率"
+  英文: null
+  定义: "天圆地方为方块添加的物理属性之一，可经 /atmosphere util 查询。"
+  出处:
+    - "https://www.mcmod.cn/item/927875.html"
+
+- 中文: "流体属性"
+  英文: null
+  出处:
+    - "https://www.mcmod.cn/item/927875.html"
+    - "https://www.mcmod.cn/item/892845.html"
+
+- 中文: "延迟警报"
+  英文: null
+  定义: "天圆地方自带性能监控机制（延迟检测功能）的预警信息之一，有限模式流体物理系统据此限制流动计算开销。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"
+
+- 中文: "延迟应急响应"
+  英文: null
+  定义: "天圆地方性能监控机制中比延迟警报更高的预警信息（响应级别）。"
+  出处:
+    - "https://www.mcmod.cn/item/919288.html"

--- a/terminology/misc.yaml
+++ b/terminology/misc.yaml
@@ -1,0 +1,48 @@
+# 天圆地方 GeoCraft 术语表 —— 杂项（跨系统待定区）
+# 范围：横跨多个系统或不属于任何游戏系统的概念（雪、冻结、径流、测试框架）。归属确定后应迁往对应文件。
+# 格式与规则见本目录 README.md。
+
+- 中文: "蒸发"
+  英文: "Evaporation"
+  定义: "使水从液态转变为气态的相变机制。"
+  出处:
+    - "https://www.mcmod.cn/item/894656.html"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.4"
+
+- 中文: "冻结"
+  英文: "Freezing"
+  定义: "水从液态转变为固态的过程。"
+  出处:
+    - "https://www.mcmod.cn/item/894657.html"
+
+- 中文: "径流"
+  英文: "Runoff"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "地表径流"
+  英文: "Surface Runoff"
+  定义: "发生在地表的径流。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "地下径流"
+  英文: "Subsurface Runoff"
+  定义: "发生在地下的径流。"
+  出处:
+    - "https://www.mcmod.cn/item/938274.html"
+
+- 中文: "造"
+  英文: null
+  定义: "作者自研的沙盒测试框架（模拟世界/方块/光照），v0.2.5 引入。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.5"
+    - "https://github.com/QGMoe/GeoCraft/tree/b1bfa0906b967e0081364de36692866275bb944d/common/src/test/java/%E6%B8%85%E6%B1%A9%E8%90%8C/%E9%80%A0"
+
+- 中文: "格文件"
+  英文: null
+  定义: "\"造\"测试框架使用的 .格 后缀测试数据文件格式，配合网格与映射器系统使用。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.5"
+    - "https://github.com/QGMoe/GeoCraft/tree/b1bfa0906b967e0081364de36692866275bb944d/common/src/test/resources/data"

--- a/terminology/nickel-nbt.yaml
+++ b/terminology/nickel-nbt.yaml
@@ -1,0 +1,21 @@
+# 天圆地方 GeoCraft 术语表 —— NickelAPI NBT 系统
+# 范围：NickelAPI 中 NBT 相关的参数类型名（NBT 标签、复合标签、路径）。
+# 格式与规则见本目录 README.md。
+- 中文: "NBT 路径"
+  英文: "NBT Path"
+  定义: "命令参数名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/geocraft/lang/en_us.lang（键 geocraft.command.atmosphere.arg.nbt_path）"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.nbt.path）"
+
+- 中文: "NBT 标签"
+  英文: "NBT Tag"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.nbt.tag）"
+
+- 中文: "NBT 复合标签"
+  英文: "NBT Compound Tag"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.nbt.compound）"

--- a/terminology/nickel.yaml
+++ b/terminology/nickel.yaml
@@ -1,0 +1,213 @@
+# 天圆地方 GeoCraft 术语表 —— NickelAPI 底层框架
+# 范围：NickelAPI 命令框架的节点体系与参数类型名（NBT 相关的见 nickel-nbt.yaml）。
+# 格式与规则见本目录 README.md。
+- 中文: "高精度十进制数"
+  英文: "BigDecimal"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.big_decimal）"
+
+- 中文: "高精度整数"
+  英文: "BigInteger"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.big_integer）"
+
+- 中文: "布尔值"
+  英文: "Boolean"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.boolean）"
+
+- 中文: "双精度浮点数"
+  英文: "Double"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.double）"
+
+- 中文: "整型"
+  英文: "Integer"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.integer）"
+
+- 中文: "长整型"
+  英文: "Long"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.long）"
+
+- 中文: "字符串"
+  英文: "String"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.string）"
+
+- 中文: "词元"
+  英文: "Token"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.token）"
+
+- 中文: "贪婪字符串"
+  英文: "Greedy String"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.greed）"
+
+- 中文: "UUID"
+  英文: "UUID"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.generic.uuid）"
+
+- 中文: "方块坐标"
+  英文: "BlockPos"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.block_pos）"
+
+- 中文: "方块"
+  英文: "Block"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.block）"
+
+- 中文: "方块状态"
+  英文: "BlockState"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.block_state）"
+
+- 中文: "目标选择器"
+  英文: "TargetSelector"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.entity_selector）"
+
+- 中文: "物品"
+  英文: "Item"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.item）"
+
+- 中文: "物品堆"
+  英文: "ItemStack"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.item_stack）"
+
+- 中文: "三维向量"
+  英文: "Vector3D"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.minecraft.vector3d）"
+
+- 中文: "流体"
+  英文: "Fluid"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.forge.fluid）"
+
+- 中文: "矿物词典"
+  英文: "Ore Directory"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.forge.ore_directory）"
+
+- 中文: "实体类型"
+  英文: "Entity Entry"
+  定义: "NickelAPI 命令参数类型名（本地化名称）"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/common/src/main/resources/assets/nickelapi/lang/en_us.lang（键 nickel.command.parameter.forge.entity_entry）"
+
+- 中文: "镍 API"
+  英文: "Nickel API"
+  定义: "从天圆地方 API 分离出的自研命令构建 API，以内置模组方式内嵌。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "参数节点"
+  英文: "ParameterNode"
+  定义: "命令节点系统中承载参数解析的节点类型。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-rc.1"
+
+- 中文: "智能分支节点"
+  英文: "SmartSplitNode"
+  定义: "命令节点系统中根据输入自动选择分支的节点。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-rc.1"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.5"
+
+- 中文: "中继执行节点"
+  英文: "RelayExecuteNode"
+  定义: "可在执行子节点完成后在 finally 块运行指定逻辑的命令节点。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.0-rc.1"
+
+- 中文: "实体类型参数节点"
+  英文: "Entity Entry Selector Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "流体参数节点"
+  英文: "Fluid Selector Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "矿物词典参数节点"
+  英文: "Ore Dictionary Selector Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "双精度浮点数三维向量参数节点"
+  英文: "Vec3d Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "For-Each 节点"
+  英文: "For-Each Node"
+  定义: "Nickel API 命令节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "物品堆参数节点"
+  英文: "Item Stack Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "维度参数节点"
+  英文: "Dimension Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "方块状态参数节点"
+  英文: "Block State Node"
+  定义: "Nickel API 命令参数节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "命令运行节点"
+  英文: "Run Command Node"
+  定义: "Nickel API 命令节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "重定向运行命令节点"
+  英文: "Redirect Command Node"
+  定义: "Nickel API 命令节点之一。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"
+
+- 中文: "字符串节点"
+  英文: "String Node"
+  定义: "Nickel API 命令参数节点之一，允许白名单、黑名单和正则过滤。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.2"

--- a/terminology/soil.yaml
+++ b/terminology/soil.yaml
@@ -1,0 +1,52 @@
+# 天圆地方 GeoCraft 术语表 —— 土壤系统
+# 范围：土壤系统的水分机制。
+# 格式与规则见本目录 README.md。
+- 中文: "土壤含水量"
+  英文: null
+  别称:
+    - ["土壤湿度"]
+    - []
+  定义: "土壤含水量，也称土壤湿度，是诸如泥土、草方块等属于土壤系统的方块所具有的特性。"
+  出处:
+    - "https://www.mcmod.cn/item/892679.html"
+
+- 中文: "下渗"
+  英文: "Infiltration"
+  定义: "包括降雨、地表径流等非土壤持有的水分从地表向下移动进入土壤的运动过程。"
+  出处:
+    - "https://www.mcmod.cn/item/892844.html"
+
+- 中文: "最大持水量"
+  英文: null
+  定义: "土壤作为多孔介质能够吸持水分使其不流动的量的上限：土壤含水量未超过该值时水不会流动，超过则缓慢流动形成壤中流。该值是土壤的特有属性，不因环境改变。"
+  出处:
+    - "https://www.mcmod.cn/item/892679.html"
+
+- 中文: "壤中流"
+  英文: null
+  定义: "土壤含水量超过最大持水量后，土壤水在土壤间缓慢移动、补充含水量较低区域所形成的径流。"
+  出处:
+    - "https://www.mcmod.cn/item/892679.html"
+
+- 中文: "被动下渗"
+  英文: null
+  定义: "土壤在随机刻更新时有概率吸收上方非土壤系统水分的下渗。"
+  出处:
+    - "https://www.mcmod.cn/item/892844.html"
+
+- 中文: "主动下渗"
+  英文: null
+  定义: "由土壤系统之外的其他游戏机制主动引发的下渗。"
+  出处:
+    - "https://www.mcmod.cn/item/892844.html"
+
+- 中文: "土壤系统"
+  英文: "Soil System"
+  别称:
+    - ["土壤（湿度）系统"]
+    - ["Soil (Moisture) System"]
+  定义: "构建在载流方块机制之上的土壤水文模拟系统。"
+  出处:
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README_EN.md"
+    - "https://github.com/QGMoe/GeoCraft/releases/tag/v0.2.6"
+    - "https://github.com/QGMoe/GeoCraft/blob/b1bfa0906b967e0081364de36692866275bb944d/README.md（章节\"土壤（湿度）系统 Soil (Moisture) System\"，EN 章节名 Soil Water）"


### PR DESCRIPTION
## 概要

新增根目录 `terminology/`，按系统分 8 个 YAML 文件收录 **217 条**中英术语：

- `general.yaml`（框架级基础概念 15）、`atmosphere.yaml`（35）、`fluidphysics.yaml`（89）、`soil.yaml`（7）、`commands.yaml`（23）、`nickel.yaml`（35）、`nickel-nbt.yaml`（3）、`misc.yaml`（跨系统待定区 10）
- 条目 schema：`中文 / 英文 / 状态 / 定义 / 出处`，可选 `又称`（现行别名）与 `旧称`（历史名）
- **英文为 null 且状态为未定 = 英文命名尚未决定，文档与翻译不得擅自命名**（当前命名待定 73 条）；另有 5 条"已使用但尚未正式定义"的概念如实记录

## 数据来源

MC 百科资料页全文（42 页）、语言文件（geocraft / nickelapi）、双语 README、历史 release note（v0.1.1–v0.2.6）、生产代码类名，以及作者对个别术语的直接判决（下垫面 = Underlying、流体更新器 = Fluid Updater、重力系统英文未定等）。

## 质量流程

两轮挖掘 → 作者点名抽查修正 4 类系统性遗漏 → 124 条抽象概念逐条回对原文的四路对抗复核（19 项定义变形/别名精度问题全部修复）→ 全文件 YAML 语法与一致性校验零问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
